### PR TITLE
fix: 注销有时不成功的bug

### DIFF
--- a/3-项目源码/templates/base/head_navbar.tmpl
+++ b/3-项目源码/templates/base/head_navbar.tmpl
@@ -109,7 +109,7 @@
 					{{end}}
 
 					<div class="divider"></div>
-					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
+					<a class="item link-action" href="javascript:void(0)" data-url="{{AppSubUrl}}/user/logout" data-redirect="{{AppSubUrl}}/">
 						<i class="octicon octicon-sign-out"></i>
 						{{.i18n.Tr "sign_out"}}<!-- Sign Out -->
 					</a>


### PR DESCRIPTION
1. 将注销按钮a标签的href属性设置为 `javascript:void(0)`